### PR TITLE
Apply reward multiplier to base reward amount

### DIFF
--- a/source/System.cpp
+++ b/source/System.cpp
@@ -482,7 +482,7 @@ void System::RewardPlayer(const RE::BGSLocation* a_location, std::uint32_t a_lev
             const auto multiplier = multipliers[quest.type];
 
             for (const auto& reward : rewards) {
-                auto amount = std::ceilf(reward.base + ((reward.quantity * a_level) * multiplier));
+                auto amount = std::ceilf((reward.base + (reward.quantity * a_level)) * multiplier);
 
                 if (reward.maximum > 0) {
                     amount > reward.maximum ? amount = reward.maximum : amount;


### PR DESCRIPTION
I would like to propose a change that will make it easier to configure static rewards independent of the boss level.

Let's take an example to walk through this change:
`Base=100, Quantity=10, Level=5, Multiplier=3`

Currently, the Multiplier is only used to increase the (Quantity X Level) part of the calculation.
```
Base + ((Quantity X Level) X Multiplier)
= 100 + ((10 X 5) X 3)
= 100 + (50 X 3)
= 250
```
This PR changes the calculation to apply the Multiplier to both Base and (Quantity X Level).
```
(Base + (Quantity X Level)) X Multiplier
= (100 + (10 X 5)) X 3
= (100 + 50) X 3
= 450
```
With this new calculation, if we set Quantity to `0.0`, it will nullify the effect of Level, but still allow the Multiplier to modify the reward amount for different enemy types.
```
(Base + (Quantity X Level)) X Multiplier
= (100 + (0 X 5)) X 3
= (100 + 0) X 3
= 300
```